### PR TITLE
Youtube verified

### DIFF
--- a/twitter_tunes/scripts/youtube_api.py
+++ b/twitter_tunes/scripts/youtube_api.py
@@ -69,7 +69,7 @@ def generate_youtube_link(parsed_list):
                 return (url_gen(video[0]), True)
         return (url_gen(parsed_list[0][0]), False)
     except IndexError:
-        return (url_gen('b_ILDFp5DGA'), True)
+        return (url_gen('b_ILDFp5DGA'), False)
 
 
 def get_link(trend):

--- a/twitter_tunes/scripts/youtube_api.py
+++ b/twitter_tunes/scripts/youtube_api.py
@@ -63,13 +63,13 @@ def generate_youtube_link(parsed_list):
     try:
         for video in parsed_list:
             if 'VEVO' in video[1]:
-                return url_gen(video[0])
+                return (url_gen(video[0]), True)
         for video in parsed_list:
             if term_checker(video[2]):
-                return url_gen(video[0])
-        return url_gen(parsed_list[0][0])
+                return (url_gen(video[0]), True)
+        return (url_gen(parsed_list[0][0]), False)
     except IndexError:
-        return url_gen('b_ILDFp5DGA')
+        return (url_gen('b_ILDFp5DGA'), True)
 
 
 def get_link(trend):

--- a/twitter_tunes/tests/test_youtube_api.py
+++ b/twitter_tunes/tests/test_youtube_api.py
@@ -209,4 +209,4 @@ def test_generate_youtube_link_keyword():
                    ('WV5sOc0Gj0w', 'Clevver News', 'dummy title'),
                    ('iv02UYr3LCY', 'Supergirl', 'dummy title')]
     url = youtube_api.generate_youtube_link(parsed_list)
-    assert url[0] == 'https://www.youtube.com/watch?v=LDtAIOgBljE'
+    assert url == ('https://www.youtube.com/watch?v=LDtAIOgBljE', True)

--- a/twitter_tunes/tests/test_youtube_api.py
+++ b/twitter_tunes/tests/test_youtube_api.py
@@ -129,7 +129,7 @@ def test_generate_youtube_link_VEVO_priority():
                    (u'xopC0UndnYY', u'Vape Capitol', 'dummy title'),
                    (u'JqNGGsYoXt0', u'West Virginia Public Broadcasting', 'dummy title')]
     url = youtube_api.generate_youtube_link(parsed_list)
-    assert url == 'https://www.youtube.com/watch?v=47dtFZ8CFo8'
+    assert url[0] == 'https://www.youtube.com/watch?v=47dtFZ8CFo8'
 
 
 def test_generate_youtube_link_VEVO_good_input():
@@ -144,7 +144,7 @@ def test_generate_youtube_link_VEVO_good_input():
                    (u'Kn0YDZ3wifU', u'The Late Late Show with James Corden', 'dummy title'),
                    (u'Ca1i6DZC3iY', u'JustinBieberVEVO', 'dummy title')]
     url = youtube_api.generate_youtube_link(parsed_list)
-    assert url == 'https://www.youtube.com/watch?v=oyEuk8j8imI'
+    assert url[0] == 'https://www.youtube.com/watch?v=oyEuk8j8imI'
 
 
 def test_generate_youtube_link_no_VEVO_good_result():
@@ -160,13 +160,13 @@ def test_generate_youtube_link_no_VEVO_good_result():
                    ('WV5sOc0Gj0w', 'Clevver News', 'dummy title'),
                    ('iv02UYr3LCY', 'Supergirl', 'dummy title')]
     url = youtube_api.generate_youtube_link(parsed_list)
-    assert url == 'https://www.youtube.com/watch?v=Cdr8_IQqT-E'
+    assert url[0] == 'https://www.youtube.com/watch?v=Cdr8_IQqT-E'
 
 
 def test_generate_youtube_link_empty_list():
     """Test Lionel Richie returned if no results from search."""
     url = youtube_api.generate_youtube_link([])
-    assert url == 'https://www.youtube.com/watch?v=b_ILDFp5DGA'
+    assert url[0] == 'https://www.youtube.com/watch?v=b_ILDFp5DGA'
 
 
 @patch('twitter_tunes.scripts.youtube_api.build')
@@ -175,7 +175,7 @@ def test_get_link_good_data(yt_search):
     mock_method.return_value = GOOD_YOUTUBE_RESPONSE
     keyword = 'Justin Bieber'
     url = youtube_api.get_link(keyword)
-    assert url == 'https://www.youtube.com/watch?v=oyEuk8j8imI'
+    assert url[0] == 'https://www.youtube.com/watch?v=oyEuk8j8imI'
 
 
 @patch('twitter_tunes.scripts.youtube_api.build')
@@ -184,7 +184,7 @@ def test_get_link_bad_data(yt_search):
     mock_method.return_value = BAD_YOUTUBE_RESPONSE
     keyword = 'asdf lawe;lfj'
     url = youtube_api.get_link(keyword)
-    assert url == 'https://www.youtube.com/watch?v=b_ILDFp5DGA'
+    assert url[0] == 'https://www.youtube.com/watch?v=b_ILDFp5DGA'
 
 
 @pytest.mark.parametrize('title, result', TITLES_TERM)
@@ -209,4 +209,4 @@ def test_generate_youtube_link_keyword():
                    ('WV5sOc0Gj0w', 'Clevver News', 'dummy title'),
                    ('iv02UYr3LCY', 'Supergirl', 'dummy title')]
     url = youtube_api.generate_youtube_link(parsed_list)
-    assert url == 'https://www.youtube.com/watch?v=LDtAIOgBljE'
+    assert url[0] == 'https://www.youtube.com/watch?v=LDtAIOgBljE'

--- a/twitter_tunes/tests/test_youtube_api.py
+++ b/twitter_tunes/tests/test_youtube_api.py
@@ -17,6 +17,22 @@ TITLES_TERM = [
     ('Fresh Piggies Music', True),
     ('', False)
 ]
+
+VERIFIED = [
+    ([('Cdr8_IQqT-E', 'Warner Bros. TV', 'dummy title'),
+      ('LDtAIOgBljE', 'Warner Bros. TV', 'dummy title music')], True),
+    ([('ObBVYoJY-dA', 'DC Entertainment', 'dummy title'),
+      ('8PrDxP5eybo', 'televisionpromosdb', 'dummy title')], False),
+    ([('hIyWCxTxPHU', 'televisionpromosdb', 'dummy title'),
+      ('_FVwpigX_18', 'Warner Bros. TV', 'dummy title')], False),
+    ([('mnC0g9KaPpU', 'The Flash Brasil', 'dummy title'),
+      ('_FVwpigX_18', 'Warner Bros. VEVO', 'dummy title')], True),
+    ([('qovt8bD1-mw', 'The TSG WB Nexus', 'Obama Song'),
+      ('WV5sOc0Gj0w', 'Clevver News', 'dummy dance')], True),
+    ([('qovt8bD1-mw', 'The TSG WB Nexus', 'Dummy Title'),
+      ('WV5sOc0Gj0w', 'Clevver News', 'other title')], False)
+]
+
 BAD_YOUTUBE_RESPONSE = {
     'etag': '"T50iqLU0cleWH2-8bQxaAS2DFh8/ZBV2w65lgyrdAoPQHuFS1_5SrKo"',
     'items': [],
@@ -127,7 +143,8 @@ def test_generate_youtube_link_VEVO_priority():
                    (u'1-pUaogoX5o', u'emimusic', 'dummy title'),
                    (u'47dtFZ8CFo8', u'CapitalCitiesVEVO', 'dummy title'),
                    (u'xopC0UndnYY', u'Vape Capitol', 'dummy title'),
-                   (u'JqNGGsYoXt0', u'West Virginia Public Broadcasting', 'dummy title')]
+                   (u'JqNGGsYoXt0', u'West Virginia Public Broadcasting',
+                   'dummy title')]
     url = youtube_api.generate_youtube_link(parsed_list)
     assert url[0] == 'https://www.youtube.com/watch?v=47dtFZ8CFo8'
 
@@ -138,10 +155,12 @@ def test_generate_youtube_link_VEVO_good_input():
                    (u'fRh_vgS2dFE', u'JustinBieberVEVO', 'dummy title'),
                    (u'DK_0jXPuIr0', u'JustinBieberVEVO', 'dummy title'),
                    (u'PfGaX8G0f2E', u'JustinBieberVEVO', 'dummy title'),
-                   (u'ztWFp63QPj4', u'The Late Late Show with James Corden', 'dummy title'),
+                   (u'ztWFp63QPj4', u'The Late Late Show with James Corden',
+                   'dummy title'),
                    (u'djzDWMy1z7k', u'JustinBieberVEVO', 'dummy title'),
                    (u'2pvGCUoGXSc', u'Clevver News', 'dummy title'),
-                   (u'Kn0YDZ3wifU', u'The Late Late Show with James Corden', 'dummy title'),
+                   (u'Kn0YDZ3wifU', u'The Late Late Show with James Corden',
+                   'dummy title'),
                    (u'Ca1i6DZC3iY', u'JustinBieberVEVO', 'dummy title')]
     url = youtube_api.generate_youtube_link(parsed_list)
     assert url[0] == 'https://www.youtube.com/watch?v=oyEuk8j8imI'
@@ -210,3 +229,9 @@ def test_generate_youtube_link_keyword():
                    ('iv02UYr3LCY', 'Supergirl', 'dummy title')]
     url = youtube_api.generate_youtube_link(parsed_list)
     assert url == ('https://www.youtube.com/watch?v=LDtAIOgBljE', True)
+
+
+@pytest.mark.parametrize('parsed_list, result', VERIFIED)
+def test_get_link_verified(parsed_list, result):
+    """Test wether a link is proven to be verified."""
+    assert youtube_api.generate_youtube_link(parsed_list)[1] == result

--- a/twitter_tunes/views.py
+++ b/twitter_tunes/views.py
@@ -20,7 +20,7 @@ def get_youtube_url(request):
     """Return YT url of a specific trend."""
     trend = request.matchdict['trend']
     search_term = parser.parse_trend(trend)
-    url = youtube_api.get_link(search_term)
+    url = youtube_api.get_link(search_term)[0]
     print(url)
     url = url.replace('watch?v=', 'embed/')
     print(url)

--- a/twitter_tunes/views.py
+++ b/twitter_tunes/views.py
@@ -1,10 +1,12 @@
 from pyramid.view import view_config
-from twitter_tunes.scripts import parser, twitter_api, youtube_api
+from twitter_tunes.scripts import parser, youtube_api
+
 
 @view_config(route_name='home', renderer='templates/index.jinja2')
 def home(request):
     # trends = twitter_api.call_twitter_api()
-    trends = ['one two step', '#two', 'kyrie', '#DogsInTheRoom', 'Patty Duke', '#Trends', '#TwitterTunes', '#Hashtag', '#Lunch Time', '#TGIF']
+    trends = ['one two step', '#two', 'kyrie', '#DogsInTheRoom', 'Patty Duke',
+              '#Trends', '#TwitterTunes', '#Hashtag', '#Lunch Time', '#TGIF']
     return {'trends': trends}
 
 


### PR DESCRIPTION
Please wait until the bot is ready for this change as it will be broken upon this merge.

Any attempt to access the youtube URL will now need to be at index 0 of the response as verified links will returned as tuple and look as follows:

(url, True) ---> Verified Link
(url, False) ---> Unverified Link

It is good to keep in mind that the unverified links may still very well contain music, we just are not able to guarantee that it actually contains music.
